### PR TITLE
feat: redirect to hypper.io, instead of www.hypper.io

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-www.hypper.io
+hypper.io


### PR DESCRIPTION
Signed-off-by: Víctor Cuadrado Juan <vcuadradojuan@suse.de>