### PR TITLE
update docs link to point to github for now

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,6 @@ disableKinds = ["section", "taxonomy", "taxonomyTerm", "RSS", "sitemap", "robots
 # rename when the logo is updated, so we indirectly also invalidate caches
 logo = "images/hypper-logo-header.png"
 githubLink = "https://github.com/rancher-sandbox/hypper"
-docsLink = "https://docs.hypper.io/"
+docsLink = "https://github.com/rancher-sandbox/hypper/blob/main/docs/SUMMARY.md"
 css = ["css/custom.css"]
 favicon = "images/favicon.ico"


### PR DESCRIPTION
This PR modifies the link to documentation to github for now (to not have dead links)