### PR TITLE
add line breaks in headlines

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -17,8 +17,8 @@ date: 2021-04-16T13:28:46+02:00
     <h4>Great For</h4>
     <div class="bg-light grid-dynamic text-center">
       <h5>Installing shared dependencies</h5>
-      <h5>Using known names and namespaces</h5>
-      <h5>Managing system level dependencies</h5>
+      <h5>Using known names<br/>and namespaces</h5>
+      <h5>Managing system level<br/>dependencies</h5>
       <h5>Opinionated cluster level charts</h5>
     </div>
   </div>


### PR DESCRIPTION
How the "Great for" looks like in Firefox, FullHD display

![hypper-bad](https://user-images.githubusercontent.com/37742/115365149-667c0d80-a1c4-11eb-8a36-c2c0788c9678.png)

How it looks like with this fix

![hypper-better](https://user-images.githubusercontent.com/37742/115365274-81e71880-a1c4-11eb-9934-73e880b774b5.png)
